### PR TITLE
finished part 2, fixed some syntax + misc. fixes

### DIFF
--- a/Spring2018/Lab6/analysis/analysis.tex
+++ b/Spring2018/Lab6/analysis/analysis.tex
@@ -1,21 +1,35 @@
-\subsection{Clamping & Distortion}
+\subsection{Differential-Mode \& Common-mode Gain}
 
-Given the voltage ranges of which the amplifying transistors work from (\ref{fig:scope_7}) and (\ref{fig:scope_8}), V_{in-} seems to exhibit a larger swing.
+The differential-mode gain and common-mode gain from simulations performed prior to this lab are approximately $20$ and $0.01$ \si{\volt}/\si{\volt}.
+$v_{out(dm)}$ and $v_{out(cm)}$ can be found by evaluating the product of the corresponding gain values and input components.
+Thus, $v_{out(dm)} = A_{dm}v_{in(dm)} = 4$\si{\volt} peak-to-peak and $v_{out(cm)} = A_{cm}v_{in(cm)} = 1$\si{\milli\volt} peak-to-peak.
+However, the result for $v_{out(dm)}$ is much too large when compared to the amplitudes seen on the oscilloscope.
+The result for $v_{out(cm)}$ is reasonable since the common-mode component of the output is typically a negligible quantity. \\
+
+Using the results from the oscilloscope, and assuming that the common-mode component of the output is negligible, $v_{out(dm)}$ can be approximated by $V_{out+} - V_{out-} = 466$\si{\milli\volt} peak-to-peak.
+The differential-mode gain can then be found: $A_{dm} = \frac{v_{out(dm)}}{v_{in(dm)}} = 2.33$ \si{\volt}/\si{\volt}.
+This is significantly lower than the value from the simulation.
+Because the common-mode output is assumed to be negligible, the common-mode gain cannot be conclusively found so the common-mode rejection ratio cannot be found either by extension.
+However, if the common-mode gain from the simulation is assumed to be correct (this is a baseless assumption), then the CMRR would be $233$. \\
+
+\subsection{Clamping \& Distortion}
+
+Given the voltage ranges of which the amplifying transistors work from (\ref{fig:scope_7}) and (\ref{fig:scope_8}), $V_{out+}$ seems to exhibit a larger swing.
 Although we biased these transistors as identically as we could with the current mirrors and DC voltage dividers, they still exhibit some differences.
-Notably, the transistor for V_{in-} clearly hits cutoff where the one for V_{in+} does not.
-The voltage variation in V_{in+} - V_{in-} was earlier found to be 3.19\si{\volt}
-Interestingly, this is approximately equal to V_{DD} - V_{t}, which is the normal limit in voltage output swing for a common-source amplifier.
+Notably, the transistor for $V_{out+}$ clearly hits cutoff where the one for V_{out-} does not.
+The voltage variation in $V_{out+} - V_{out-}$ was earlier found to be 3.19\si{\volt}
+Interestingly, this is approximately equal to $V_{DD} - V_{t}$, which is the normal limit in voltage output swing for a common-source amplifier.
 
-/FloatBarrier
+\FloatBarrier
 
 \begin{figure}[h!]
 	\centering
 	\includegraphics[scale=0.60]{./images/scope_6}
-	\caption{Measured maximum signal swing of V_{in+} from a 1.5\si{\volt} p/p input at 1MHz}
+	\caption{Measured maximum signal swing of $V_{out+}$ and $V_{out-}$ from a 1.5\si{\volt} p/p input at 1MHz}
 	\label{fig:scope_6}
 \end{figure}
 
-/FloatBarrier
+\FloatBarrier
 
 Therefore, for this differential amplifier, the input signal magnitude should be no greater than 1.5V p/p to avoid significant distortion in signal.
 This quantity is similar to the output voltage swing divided by A_{DM}.

--- a/Spring2018/Lab6/calculations/calculations.tex
+++ b/Spring2018/Lab6/calculations/calculations.tex
@@ -1,11 +1,36 @@
-\subsection{Clamping & Distortion}
+\subsection{Differential-Mode \& Common-mode Gain}
 
-/FloatBarrier
+A sine wave centered at $0$\si{\volt} with amplitude $100$\si{\milli\volt} and frequency $1$\si{\mega\hertz} is applied to $v_{in}$ as indicated by the differential amplifier circuit schematic. 
+The oscilloscope displayed the following waveforms for $V_{out+}$ and $V_{out-}$.
+
+\FloatBarrier
+
+\begin{figure}[h!]
+	\centering
+	\includegraphics[scale=0.60]{./images/scope_5}
+	\caption{$V_{out+}$ (4), $V_{out-}$ (3), and $V_{out+} - V_{out-}$ for $100$\si{\milli\volt} input at $1$\si{\mega\hertz}}
+	\label{fig:scope_5}
+\end{figure}
+
+\FloatBarrier
+
+As expected, $V_{out+}$ and $V_{out-}$ are $180$ degrees out of phase.
+The peak-to-peak amplitudes of $V_{out+}$ and $V_{out-}$ are $263$ and $203$\si{\milli\volt}, respectively.
+By taking the sum of the amplitudes, $V_{out+} - V_{out-} = 466$\si{\milli\volt} peak-to-peak. \\
+
+The voltage applied to $V_{in-}$ has an ac amplitude of $100$\si{\milli\volt}.
+The voltage applied to $V_{in+}$ has no ac component.
+From these input signals, the differential-mode component of the input $v_{in(dm)} = v_{in+} - v_{in-} = -100$\si{\milli\volt} amplitude or $200$\si{\milli\volt} peak-to-peak.
+The common-mode component of the input $v_{in(cm)} = \frac{1}{2}(v_{in+} + v_{in-}) = 50$\si{\milli\volt} amplitude or $100$\si{\milli\volt} peak-to-peak. \\
+
+\subsection{Clamping \& Distortion}
+
+\FloatBarrier
 
 \begin{figure}[h!]
 	\centering
 	\includegraphics[scale=0.60]{./images/scope_7}
-	\caption{Measured maximum signal swing of V_{in-} from a 2\si{\volt} p/p input at 1MHz}
+	\caption{Measured maximum signal swing of $V_{out+}$ from a 2\si{\volt} p/p input at 1MHz}
 	\label{fig:scope_7}
 \end{figure}
 
@@ -14,13 +39,13 @@
 \begin{figure}[h!]
 	\centering
 	\includegraphics[scale=0.60]{./images/scope_8}
-	\caption{Measured maximum signal swing of V_{in+} from a 2\si{\volt} p/p input at 1MHz}
+	\caption{Measured maximum signal swing of $V_{out-}$ from a 2\si{\volt} p/p input at 1MHz}
 	\label{fig:scope_8}
 \end{figure}
 
 \FloatBarrier
 
-From the cursors in (\ref{fig:scope_7}), V_{in-} ranges from 5.075 to 3.262 \si{\volt}, resulting in a swing of 1.81\si{\volt}.
-Similarly, the cursors in (\ref{fig:scope_8}) reveal a range of 1.38\si{\volt}.
-Thus, the voltage range for the signal V_{out+} - V_{out-} is the sum of these two ranges, or 3.19\si{\volt}.
-From these parameters, an input signal that will avoid clipping should be lower than 3.19\si{\volt} / A_{DM} \approx 1.5 \si{\volt}.
+From the cursors in (\ref{fig:scope_7}), $V_{out+}$ ranges from 5.075 to 3.262 \si{\volt}, resulting in a swing of 1.81\si{\volt}.
+Similarly, the cursors in (\ref{fig:scope_8}) reveal a range of 1.38\si{\volt} for $V_{out-}$.
+Thus, the voltage range for the signal $V_{out+} - V_{out-}$ is the sum of these two ranges, or 3.19\si{\volt}.
+From these parameters, an input signal that will avoid clipping should be lower than 3.19\si{\volt} / $A_{dm}$ \approx 1.5 \si{\volt}.

--- a/Spring2018/Lab6/conclusion/conclusion.tex
+++ b/Spring2018/Lab6/conclusion/conclusion.tex
@@ -1,4 +1,27 @@
-/subsection{Clamping & Distortion}
-The output voltage swing of V_{in+}, V_{in-}, and of V_{in+} - V_{in-} is overall consistent with the simulated differential amplifier.
+\subsection{Differential-Mode \& Common-mode Gain}
+The differential amplifier produced results that are clear and easily measurable.
+However, the differential-mode gain of the amplifier is observed to be a whole order of magnitude lower than the results from simulation.
+This may be partly due to high frequency attentuation since the circuit is operating at a relatively fast $1$\si{\mega\hertz} frequency. 
+When the frequency of $v_{in}$ is changed to $1$\si{\kilo\hertz}, the output amplitudes increase.
+
+\FloatBarrier
+
+\begin{figure}[h!]
+	\centering
+	\includegraphics[scale=0.60]{./images/scope_2}
+	\caption{$V_{out+}$ (4), $V_{out-}$ (3), and $V_{out+} - V_{out-}$ for $100$\si{\milli\volt} input at $1$\si{\kilo\hertz}}
+	\label{fig:scope_2}
+\end{figure}
+
+\FloatBarrier
+
+Also, it is observed that transistors M1A and M1B have a slight mismatch as $V_{out+}$ and $V_{out-}$ vary by $60$\si{\milli\volt} and the drain currents on each side of the differential amplifier vary by $6$\si{\micro\amp}.
+Other inconsistancies may be due to slight variations in resistor values as well.
+Overall, the differential amplifier exhibited behavior within the realm of expectation. \\
+
+
+
+\subsection{Clamping \& Distortion}
+The output voltage swing of $V_{in+}$, $V_{in-}$, and of $V_{in+} - V_{in-}$ is overall consistent with the simulated differential amplifier.
 When one transistor is near cutoff, the other is near triode, and vice-versa so that the differential mode output is large.
-The value of the differential mode output swing is near the expected value of V_{DD} - V_{t}, which when divided by A_{DM} is consistent with the maximum input amplitude that we found to incur only slight distortion.
+The value of the differential mode output swing is near the expected value of $V_{DD} - V_{t}$, which when divided by $A_{dm}$ is consistent with the maximum input amplitude that we found to incur only slight distortion.

--- a/Spring2018/Lab6/descriptions/descriptions.tex
+++ b/Spring2018/Lab6/descriptions/descriptions.tex
@@ -1,14 +1,14 @@
 First, the left hand portion of the current source is constructed.
-The resistor is tuned to get the proper $225$\si{\micro\ampere} current.
+The resistor $R_{ref}$ is tuned to get the proper $225$\si{\micro\ampere} current.
 A $10$\si{\kilo\ohm} resistor is used, which yields a $213$\si{\micro\ampere} current.
 The two transistors for the current sources are then attached.
-Since each current source is expected to produce $225$\si{\micro\ampere}, the total current is expected to be $450$\si{\micro\ampere}.
-Their total current is measured to be about $480$\si{\micro\ampere}, which is quite close.
+Since each current source is expected to produce $225$\si{\micro\ampere}, the total current $I_{SS}$ is expected to be $450$\si{\micro\ampere}.
+Their total current $I_{SS}$ is measured to be about $480$\si{\micro\ampere}, which is quite close.
 They are tested by setting the drain voltage sufficiently high so both of the transistors on the right-hand of the current source enter saturation. \\
 
 The first voltage divider is then constructed and tested with two $5$\si{\kilo\ohm} in series.
 Common source amplifiers are constructed with $M_{1A}$ and $M_{1B}$.
-Two $5$\si{\kilo\ohm} resistors in series turn out to be sufficient to ensure that both transistors at the voltage input are biased in the middle of the saturation region, which corresponds to an output voltage of about $3.0$\si{\volt}. \\
+A $5$\si{\kilo\ohm} and $10$\si{\kilo\ohm} resistor in parallel ($3.3$\si{\kilo\ohm} equivalent resistance) for $R_D$ turn out to be sufficient to ensure that both transistors at the voltage input are biased in the middle of the saturation region, which corresponds to an output voltage of about $3.0$\si{\volt}. \\
 
 The current sources and the two halves of the differential pair are then connected to form the final amplifier.
 The bias current on either half of the differential pair is expected to be about $225$\si{\micro\ampere}.


### PR DESCRIPTION
Also, I realized that input 3 is Vout+ and input 4 is Vout- on the oscope. This is evident when you look at the scope images, since Vout+ should appear to be in phase with (Vout+ - Vout-). I made the necessary changes in the report to fix this, but double check in case I missed something. Thanks!